### PR TITLE
Feedback

### DIFF
--- a/feedback/stability-paths-def.R
+++ b/feedback/stability-paths-def.R
@@ -1,0 +1,35 @@
+sample_without_replacement <- function(nrows, strata = NULL, fraction = 0.5) {
+  if (is.null(strata)) {
+    return(sample(1:nrows, size = ceiling(nrows * fraction), replace = FALSE))
+  }
+  # vectorize subsampling over:
+  # <rows belonging to the different strata>,
+  strata_index <- split(seq_len(nrows), strata)
+  # <subsample sizes in different strata>
+  # round up so that subsample has at least 1 member from each strata
+  strata_sizes <- ceiling(table(strata) * fraction)
+  rows <- mapply(sample,
+    x = strata_index, size = strata_sizes,
+    replace = FALSE
+  )
+  unlist(rows)
+}
+
+# extract <# subset sizes> x <# covariates> inclusion indicator matrix
+# from fitted subset selection model <new_model>
+get_selected <- function(new_model) {
+  selected <- summary(new_model)$which
+  # add (named) row for null model / maximal regularization: intercept only
+  selected <- rbind("0" = rep(FALSE, ncol(selected)), selected)
+  # remove intercept column & return
+  selected[, colnames(selected) != "(Intercept)"]
+}
+
+# collapse list of selection indicator matrices <selected> into
+# a single matrix containing frequencies of inclusion
+make_paths <- function(selected) {
+  # add all matrices elementwise and divide by their number to
+  # get elementwise means
+  Reduce(`+`, selected) / length(selected)
+}
+

--- a/feedback/stability-plot-def.R
+++ b/feedback/stability-plot-def.R
@@ -1,0 +1,48 @@
+plot_stability_paths <- function(stability_paths, path_pars = list(),
+                                 label_pars = list(), ...) {
+  opar <- par(no.readonly = TRUE)
+  on.exit(par(opar))
+
+  checkmate::assert_matrix(stability_paths, mode = "numeric",
+    any.missing = FALSE, col.names = "named")
+
+  new_pars <- list(...)
+  default_pars <- list(mar = opar$mar + c(0, 0, 0, 1))
+  do.call(par, modifyList(default_pars, new_pars))
+
+  n_covariates <- ncol(stability_paths)
+  n_step <- nrow(stability_paths)
+
+  # default qualitative palette:
+  col <- hcl(
+    h = seq(0, 360, l = n_covariates + 1) + 15, c = 100,
+    l = 65
+  )[-(n_covariates + 1)]
+
+  default_path_pars <- list(
+    lty = 1, type = "b", bty = "n", col = col,
+    x = 0:(n_step - 1), pch = 19, xlab = "# covariates",
+    ylab = expression(Pi), ylim = c(0, 1)
+  )
+  path_pars <- c(
+    list(y = stability_paths),
+    modifyList(default_path_pars, path_pars)
+  )
+  do.call(matplot, path_pars)
+
+  # arrange labels according to mean inclusion probability
+  rank_covariate <- rank(colMeans(stability_paths), ties.method = "first")
+  label_pos <- seq(0, 1, l = n_covariates)[rank_covariate]
+  ## alternatively:  vertical position = mean inclusion probability
+  ## # label_pos <- colMeans(stability_paths)
+  ## ## scale to [0, 1] for better spacing:
+  ## # label_pos <- (label_pos - min(label_pos))/diff(range(label_pos))
+
+  default_label_pars <- list(
+    text = colnames(stability_paths), side = 4,
+    at = label_pos, col = col, las = 1
+  )
+  label_pars <- modifyList(default_label_pars, label_pars)
+
+  do.call(mtext, label_pars)
+}


### PR DESCRIPTION
@marquach 

Fehlende Funktionen gut implementiert, passt. 

(Das resampling ginge in einer zeile und ohne for-loop und ohne mühsam-manuelles indexrumgefummel mittels `mapply`, vgl musterlösung.)

--------------------------------------------

- https://github.com/fort-w2021/stability-ex-marquach/blob/d54a0608dd7e20fd3e2b98cd729ba498aea4e939/topdown-stability-sol.Rmd#L36-L39
"Beim Boosting koennen doch Kovariablen sehr haeufig am Ende ausgewählt werden, obwohl diese eigentlich gar nichts mehr beitragen." soweit volle zustimmung, beim rest eher nicht.  
Der regularisierungsparameter beim boosting ist die anzahl iterationen (genauer: eigentlich die kombi von steplength und # iterations). wenn ne variable nur noch in der "overfitting-phase" bei den späten iterationen reinkommt (i.e, "eigentlich gar nichts mehr beitragen"), sollte die stability selection das abfangen --erstens weil  in den ge-resampelten datensätzen, wenn die variable tatsächlich eigentlich nix bringt, dann mit geringer w.keit immer diese selbe variable ausgewählt werden wird und zweitens weil variablen die erst bei sehr schwacher regularisierung (also: bei hoher boosting iterationszahl) ins model kommen von der stability selection ja eben eh rausgekickt werden. 

- https://github.com/fort-w2021/stability-ex-marquach/blob/d54a0608dd7e20fd3e2b98cd729ba498aea4e939/topdown-stability-sol.Rmd#L147-L148 
styleguide: 80 zeichen pro zeile und nicht mehr, machen sie halt nach der zuweisung `<-` nen zeilenumbruch wenn sie in RStudio diese "Vertically align arguments in auto-indent" option benutzen und das zuweisungsziel schon die 40 zeichen verbraucht....

- https://github.com/fort-w2021/stability-ex-marquach/blob/d54a0608dd7e20fd3e2b98cd729ba498aea4e939/topdown-stability-sol.Rmd#L276-L277 styleguide: bitte semantisch korrekte einrückungen

- https://github.com/fort-w2021/stability-ex-marquach/blob/d54a0608dd7e20fd3e2b98cd729ba498aea4e939/topdown-stability-sol.Rmd#L240 joar, besser als nix. wirklich sinnvoll wird der input check aber erst wenn sie dann halt wirklich die ganzen impliziten annahmen über diese matrix auch explizit abprüfen: die ist numerisch, die hat keine NAs, die einträge sind >= 0 und <=1, und die hat benamte spalten.

- https://github.com/fort-w2021/stability-ex-marquach/blob/d54a0608dd7e20fd3e2b98cd729ba498aea4e939/topdown-stability-sol.Rmd#L306-L309 
wieso, ist doch wunderbar?  exakt das selbe produzieren zu wollen ist mühsam, ja, aber da ggplot2 ziemlich vernünftige defaults hat muss man finde ich gar nicht soo viel aufwand treiben. directlabels ist eine nette alternative zu legenden (legenden sind ja eher schlecht weil sie einen zwingen mit der aufmerksamkeit zwischen der grafik selbst und der legende zu wechseln):

```r
plot_stability_paths_ggplot <- function(stability_paths){
  library(ggplot2)
  library(directlabels) # !!
  #Input check
  checkmate::assert_matrix(stability_paths, 
    mode = "numeric", any.missing = FALSE, col.names = "unique") # !!
  stopifnot(all(stability_paths >= 0 &  stability_paths <= 1))   # !!

  number_covariables <- ncol(stability_paths)
  
  ggplot_stability_paths <- 
    cbind(tidyr::gather(as.data.frame(stability_paths), key, values),
     "number_covariables" = seq(0,number_covariables,1) )
  
  ggplot(data = ggplot_stability_paths, 
        aes(x = number_covariables, y = values, col = key)) +
    geom_point(size = 2) +
    geom_line() +
    xlab("# covariates") + ylab(expression(Pi)) +
    theme_minimal() + # !!
    theme(legend.position = "none") +  # !!
    directlabels::geom_dl(aes(label = key), method = "far.from.others.borders") # !!
}
```
![image](https://user-images.githubusercontent.com/998541/107492588-ee261a00-6b8c-11eb-9bde-e3284a60b1ed.png)

- https://github.com/fort-w2021/stability-ex-marquach/blob/d54a0608dd7e20fd3e2b98cd729ba498aea4e939/topdown-stability-sol.Rmd#L310 was meinen sie damit...?